### PR TITLE
Fix typo in L1-SBAS/SAIF preamble definition

### DIFF
--- a/src/sdrinit.c
+++ b/src/sdrinit.c
@@ -524,7 +524,7 @@ extern int initnavstruct(int sys, int ctype, int prn, sdrnav_t *nav)
     int pre_b1i[11]= {-1,-1,-1, 1, 1, 1,-1, 1, 1,-1, 1}; /* B1I preamble */
     int pre_sbs[24]= { 1,-1, 1,-1, 1, 1,-1,-1,-1, 1,
                        1,-1,-1, 1,-1, 1,-1,-1, 1, 1,
-                       1 -1,-1, 1}; /* SBAS L1/QZS L1SAIF preamble */
+                       1,-1,-1, 1}; /* SBAS L1/QZS L1SAIF preamble */
 
     int poly[2]={V27POLYA,V27POLYB};
 


### PR DESCRIPTION
This explains why the decoded SBAS message rate I was seeing was far less than the expected ~1/3 Hz.